### PR TITLE
Flesh out CI, software environment, and tests.

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -25,7 +25,7 @@ jobs:
         channels: conda-forge,defaults
         channel-priority: true
         python-version: ${{ matrix.python-version }}
-        activate-environment: python-template
+        activate-environment: pudl-catalog
         environment-file: environment.yml
     - shell: bash -l {0}
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Catalyst specific files
+commit.txt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -103,6 +106,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env_tox/
 .venv
 env/
 venv/

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   # Packages specified in setup.py that need or benefit from binary conda packages
   # - geopandas>=0.9,<0.11
   # - pygeos>=0.10,<0.13  # Python wrappers for the GEOS spatial libraries
-  # - python-snappy>=0.6,<0.7  # Supports snappy compression in pyarrow/parquet
+  - python-snappy>=0.6,<0.7  # Supports snappy compression in pyarrow/parquet
 
   # Packages not specified in setup.py that provide optional, helpful binaries:
   # - numba>=0.55.1,<0.56  # numba speeds up some kinds of math by 100x

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,11 @@ setup(
     zip_safe=False,
     python_requires=">=3.8,<3.11",
     install_requires=[
+        "gcsfs>=2022,<2023",
         "intake>=0.6.5",
         "intake_parquet>=0.2.3",
         "intake_sql>=0.3.1",
+        "msgpack>=1,<2",
         "pandas>=1.4,<1.5",
     ],
     extras_require={

--- a/src/pudl_catalog/__init__.py
+++ b/src/pudl_catalog/__init__.py
@@ -7,24 +7,25 @@ import intake
 
 import pudl_catalog.helpers  # noqa: F401
 
-KNOWN_DATA_LOCATIONS = [
-    "https://storage.googleapis.com/intake.catalyst.coop/test",
-    "gs://intake.catalyst.coop/test",
-]
+BASE_URLS = {
+    "gs": "gs://intake.catalyst.coop/test",
+    "https": "https://storage.googleapis.com/intake.catalyst.coop/test",
+}
 
 # Ensure that the user has set the relevant environment variables
 if os.getenv("PUDL_INTAKE_PATH") is None:
     msg = (
-        "Environment variable PUDL_INTAKE_PATH not set, `catalystcoop.pudl_catalog`\n"
-        "may not work as expected. Known data locations include:\n"
-        f"{KNOWN_DATA_LOCATIONS}."
+        "Environment variable PUDL_INTAKE_PATH is not set. Without that path \n"
+        "`catalystcoop.pudl_catalog` will not work as expected.\n"
+        f"Known data locations include: {list(BASE_URLS.values())}.\n"
+        f"Defaulting to {BASE_URLS['gs']}"
     )
     warnings.warn(msg)
 
 if os.getenv("PUDL_INTAKE_CACHE") is None:
     msg = (
         "Environment variable PUDL_INTAKE_CACHE not set, `catalystcoop.pudl_catalog`\n"
-        "may not work as expected. Choose a location for local file caching to speed\n"
+        "may not work as expected. Set a location for local file caching to speed\n"
         "repeated data queries."
     )
     warnings.warn(msg)

--- a/src/pudl_catalog/hourly_emissions_epacems.py
+++ b/src/pudl_catalog/hourly_emissions_epacems.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import intake
 import pandas as pd
 
+from pudl_catalog import BASE_URLS
 from pudl_catalog.helpers import year_state_filter
 
 logger = logging.getLogger(__name__)
@@ -18,8 +19,8 @@ class TestEpaCemsParquet(object):
     """Test the EPA CEMS Intake Catalog."""
 
     table_name: str = "hourly_emissions_epacems"
-    gs_base: str = "gs://intake.catalyst.coop/test"
-    https_base: str = "https://storage.googleapis.com/intake.catalyst.coop/test"
+    gs_base: str = BASE_URLS["gs"]
+    https_base: str = BASE_URLS["https"]
     local_base: str = str(Path(__file__).parent.parent.parent / "data")
     pudl_catalog_yml: str = "../src/catalog/pudl-catalog.yml"
 

--- a/tests/hourly_emissions_epacems_test.py
+++ b/tests/hourly_emissions_epacems_test.py
@@ -1,24 +1,105 @@
 """Test cases for the EPA CEMS data source."""
+import logging
+import os
+import time
+from typing import Literal
 
+import intake
+import pandas as pd
 import pytest
+from pandas.testing import assert_frame_equal
 
-from pudl_catalog.hourly_emissions_epacems import TestEpaCemsParquet
+from pudl_catalog import BASE_URLS
+from pudl_catalog.helpers import year_state_filter
+
+logger = logging.getLogger(__name__)
 
 TEST_YEARS = [2020]
 TEST_STATES = ["ID"]
+TEST_FILTERS = year_state_filter(years=TEST_YEARS, states=TEST_STATES)
+
+os.environ["PUDL_INTAKE_PATH"] = BASE_URLS["gs"]
+
+
+def parquet_url(
+    protocol: Literal["gs", "https"],
+    partition: bool,
+    table_name: str,
+) -> str:
+    """Construct the path to a particular parquet table resource."""
+    try:
+        url = BASE_URLS[protocol]
+    except KeyError:
+        raise ValueError(
+            f"Received invalid protocol: {protocol}. Must be one of 'gs' or 'https'."
+        )
+    url = url + "/" + table_name
+    if not partition:
+        url += ".parquet"
+    return url
 
 
 @pytest.fixture(scope="module")
-def epacems_tester():
-    """Create an EPA CEMS testing object."""
-    return TestEpaCemsParquet()
+def expected_df() -> pd.DataFrame:
+    """Read parquet data directly for comparison with Intake outputs."""
+    logger.info("Reading remote test data for comparison using pd.read_parquet().")
+    epacems_url = parquet_url(
+        protocol="gs",
+        partition=False,
+        table_name="hourly_emissions_epacems",
+    )
+    return pd.read_parquet(epacems_url, filters=TEST_FILTERS)
 
 
-def test_direct(epacems_tester):
+@pytest.mark.parametrize(
+    "protocol,partition",
+    [
+        ("gs", False),
+        ("gs", True),
+    ],
+)
+def test_read_parquet(
+    protocol: Literal["gs", "https"],
+    partition: bool,
+    expected_df: pd.DataFrame,
+) -> None:
     """Test direct access via read_parquet()."""
-    epacems_tester.test_direct(years=TEST_YEARS, states=TEST_STATES)
+    logger.info(
+        f"read_parquet, {protocol=}, {partition=}, {TEST_YEARS=}, {TEST_STATES=}:"
+    )
+    epacems_url = parquet_url(
+        protocol=protocol, partition=partition, table_name="hourly_emissions_epacems"
+    )
+    start_time = time.time()
+    df = pd.read_parquet(epacems_url, filters=TEST_FILTERS)
+    elapsed_time = time.time() - start_time
+    logger.info(f"    elapsed time: {elapsed_time:.2f}s")
+    assert_frame_equal(df, expected_df)
 
 
-def test_intake(epacems_tester):
-    """Test direct access via read_parquet()."""
-    epacems_tester.test_intake(years=TEST_YEARS, states=TEST_STATES)
+@pytest.mark.parametrize(
+    "protocol,partition",
+    [
+        ("gs", False),
+        ("gs", True),
+    ],
+)
+def test_intake_catalog(
+    protocol: Literal["gs", "https"],
+    partition: bool,
+    expected_df: pd.DataFrame,
+) -> None:
+    """Test reading data from the intake catalog."""
+    logger.info(
+        f"intake_catalog, {protocol=}, {partition=}, {TEST_YEARS=}, {TEST_STATES=}:"
+    )
+    os.environ["PUDL_INTAKE_PATH"] = BASE_URLS[protocol]
+    pudl_cat = intake.cat.pudl_cat(cache_method="")
+    src = "hourly_emissions_epacems"
+    if partition:
+        src += "_partitioned"
+    start_time = time.time()
+    df = pudl_cat[src](filters=TEST_FILTERS).to_dask().compute()
+    elapsed_time = time.time() - start_time
+    logger.info(f"    elapsed time: {elapsed_time:.2f}s")
+    assert_frame_equal(df, expected_df)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ passenv =
     CONDA_PREFIX
     GITHUB_*
     HOME
-    PUDL_INTAKE
+    PUDL_INTAKE_*
 covargs = --cov={envsitepackagesdir}/pudl_catalog --cov-append --cov-report=xml
 covreport = coverage report --sort=cover
 
@@ -24,7 +24,7 @@ covreport = coverage report --sort=cover
 description = Run the full suite of flake8 linters on the PUDL codebase.
 skip_install = false
 extras =
-    test
+    tests
 commands =
     flake8
 
@@ -32,7 +32,7 @@ commands =
 description = Run git pre-commit hooks not covered by the other linters.
 skip_install = false
 extras =
-    test
+    tests
 commands =
     pre-commit run --all-files --show-diff-on-failure python-check-blanket-noqa
     pre-commit run --all-files --show-diff-on-failure python-no-eval
@@ -58,7 +58,7 @@ description = Run all continuous integration (CI) checks & generate test coverag
 skip_install = false
 recreate = true
 extras =
-    test
+    tests
     {[testenv:linters]extras}
 commands =
     coverage erase


### PR DESCRIPTION
* Use correct conda environment in GitHub Actions workflow.
* Add python-snappy to the pudl-catalog conda environment.
* Add gcsfs to package dependencies.
* Add msgpack to package dependencies, even though in theory it should already be
  getting installed because it's a dependency of intake. Not sure what's going on there.
  Maybe @martindurant knows?
* Use the google storage location for the catalog by default if none is set by the user.
* Refer to the top level package constants for the known data locations elsewhere in the
  package.
* Re-write the tests to just use a small amount of remote data.
* Fix extras in tox.ini to refer to "tests" not "test"
* Pass PUDL_INTAKE_* environment variables in to Tox.