### PR TITLE
Update to work with dask 2022.4.2 and pyarrow 8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
   rev: v5.0.0
   hooks:
   - id: rstcheck
-#   additional_dependencies: [sphinx]
+    additional_dependencies: [sphinx]
     args: [--config, tox.ini]
 
 - repo: local

--- a/README.rst
+++ b/README.rst
@@ -222,8 +222,13 @@ on that dataframe to actually read the data and return a pandas dataframe:
        states=["ID", "CO", "TX"],
    )
    epacems_df = (
-       pudl_cat.hourly_emissions_epacems(filters=filters)
-       .to_dask().compute()
+       pudl_cat.hourly_emissions_epacems(
+           filters=filters
+           index=False,
+           split_row_groups=True,
+       )
+       .to_dask()
+       .compute()
    )
    epacems_df[[
        "plant_id_eia",

--- a/src/pudl_catalog/__init__.py
+++ b/src/pudl_catalog/__init__.py
@@ -30,6 +30,7 @@ if os.getenv("PUDL_INTAKE_CACHE") is None:
         "Environment variable PUDL_INTAKE_CACHE is not set. "
         f"Defaulting to {os.getenv('HOME')}/.intake/cache"
     )
+    os.environ["PUDL_INTAKE_CACHE"] = str(Path.home() / ".intake/cache")
 
 # The catalog is a YAML file in the same directory as this init file
 _pudl_catalog_path = Path(__file__).parent.resolve() / "pudl_catalog.yaml"

--- a/tests/integration/hourly_emissions_epacems_test.py
+++ b/tests/integration/hourly_emissions_epacems_test.py
@@ -99,7 +99,16 @@ def test_intake_catalog(
     if partition:
         src += "_partitioned"
     start_time = time.time()
-    df = pudl_cat[src](filters=TEST_FILTERS, cache_method="").to_dask().compute()
+    df = (
+        pudl_cat[src](
+            filters=TEST_FILTERS,
+            cache_method="",
+            index=False,
+            split_row_groups=True,
+        )
+        .to_dask()
+        .compute()
+    )
     elapsed_time = time.time() - start_time
     logger.info(f"    elapsed time: {elapsed_time:.2f}s")
-    assert_frame_equal(df, expected_df)
+    assert_frame_equal(df, expected_df, check_categorical=False)


### PR DESCRIPTION
* Set `PUDL_INTAKE_CACHE` to the default value if it is found unset.
* Use `index=False` and `split_row_groups=True` in the tests and
  examples when reading from the catalog, since the monolithic file
  is huge and otherwise it'll end up in a single dataframe.
* When comparing actual and expected dataframes in the integration
  tests, don't require CategoricalDtypes to be identical, since the
  known categories include only ID in one dataframe and all the states
  in the other (since they're part of the parquet metdata?) even though
  the data is identical.