### PR TITLE
Update to allow Python 3.11

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     rev: 22.10.0
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3.11
 
   # Check for PEP8 non-compliance, code complexity, style, errors, etc:
   - repo: https://github.com/PyCQA/flake8

--- a/environment.yml
+++ b/environment.yml
@@ -5,12 +5,13 @@ channels:
 dependencies:
   # Packages required for setting up the environment
   - pip>=21,<23
-  - python>=3.8,<3.11
-  - setuptools<62
+  - python>=3.8,<3.12
+  - setuptools<66
 
   # Packages that need or benefit from or provide binary conda packages
   - python-snappy>=0.6,<0.7 # Supports snappy compression in pyarrow/parquet
-  - numba>=0.55.1,<0.56 # numba speeds up some kinds of math by 100x
+  - cramjam>=2.6 # Supports snappy compression w/o a system library
+  # - numba>=0.55.1,<0.57 # numba JITC, not yet Python 3.11 compatible
   - google-cloud-sdk>=388
 
   # Jupyter packages:

--- a/environment.yml
+++ b/environment.yml
@@ -9,12 +9,10 @@ dependencies:
   - setuptools<66
 
   # Packages that need or benefit from or provide binary conda packages
-  - python-snappy>=0.6,<0.7 # Supports snappy compression in pyarrow/parquet
-  - cramjam>=2.6 # Supports snappy compression w/o a system library
   # - numba>=0.55.1,<0.57 # numba JITC, not yet Python 3.11 compatible
   - google-cloud-sdk>=388
 
-  # Jupyter packages:
+  # Jupyter packages for interactive development / testing
   - jupyterlab>=3.2,<4
   - jupyter-resource-usage>=0.5,<0.7
   - nbconvert>=6,<7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,14 @@
 [build-system]
-requires = ["setuptools<62", "pip>=21,<23", "wheel", "setuptools_scm"]
+requires = [
+    "setuptools<66",
+    "setuptools_scm[toml]>=3.5.0",
+]
 
 [tool.setuptools_scm]
 
 [tool.black]
 line-length = 88
-target-version = ["py38", "py39", "py310"]
+target-version = ["py38", "py39", "py310", "py311"]
 include = "\\.pyi?$"
 
 [tool.isort]

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
     ],
     packages=find_packages("src"),
@@ -43,11 +44,12 @@ setup(
     include_package_data=True,
     package_data={"": ["*.yml", "*.yaml"]},
     zip_safe=False,
-    python_requires=">=3.8,<3.11",
+    python_requires=">=3.8,<3.12",
     install_requires=[
         "gcsfs>=2021.7,<2022.11.1",
         "intake_parquet>=0.2.3,<0.3",
-        "intake_sqlite>=0.1.2",
+        # "intake_sqlite>=0.1.2",
+        "intake_sqlite @ git+https://github.com/catalyst-cooperative/intake-sqlite@dev",
         "msgpack>=1,<2",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,7 @@ setup(
     install_requires=[
         "gcsfs>=2021.7,<2022.11.1",
         "intake_parquet>=0.2.3,<0.3",
-        # "intake_sqlite>=0.1.2",
-        "intake_sqlite @ git+https://github.com/catalyst-cooperative/intake-sqlite@dev",
+        "intake_sqlite>=0.2.0",
         "msgpack>=1,<2",
     ],
     extras_require={


### PR DESCRIPTION
* Update to use `intake-sqlite>=v0.2.0` which allows Python 3.11.
* Update GitHub workflow test matrix to include py311
* Change black language version to 3.11 in .pre-commit-config.yaml
* Bump max python version in environment.yml to 3.11
* Comment out numba, not yet compatible with 3.11
* Temporarily add cramjam in conda env, which supports snappy compression without python-snappy system library. Unfortunately it doesn't currently have a MacOS binary wheel for Python 3.11. But I filed [an issue](https://github.com/milesgranger/pyrus-cramjam/issues/91)
* Remove pip/wheel from pyproject.toml & update setuptools/scm_setuptools versions
* Removed python-snappy from the conda environment, since snappy compression is now provided by cramjam.

## Don't merge until
* [x] cramjam dependency issue has been addressed: https://github.com/milesgranger/pyrus-cramjam/issues/91