### PR TITLE
Skip gcs integration tests to avoid egress fees

### DIFF
--- a/tests/integration/hourly_emissions_epacems_test.py
+++ b/tests/integration/hourly_emissions_epacems_test.py
@@ -82,6 +82,11 @@ def test_read_parquet(
     expected_df: pd.DataFrame,
 ) -> None:
     """Test direct access via read_parquet()."""
+    if protocol == "gs":
+        pytest.skip(
+            "Skip GCS test until we figure out how to pull smaller partitions of the data to avoid large egress fees."
+        )
+
     logger.debug(f"read_parquet, {protocol=}, {partition_suffix=}")
     epacems_url = parquet_url(
         protocol=protocol,
@@ -119,6 +124,11 @@ def test_intake_catalog(
     tmp_path: Path,
 ) -> None:
     """Test reading data from the intake catalog."""
+    if protocol == "gs":
+        pytest.skip(
+            "Skip GCS test until we figure out how to pull smaller partitions of the data to avoid large egress fees."
+        )
+
     logger.debug(f"intake_catalog, {protocol=}, {partition_suffix=}")
     os.environ["PUDL_INTAKE_PATH"] = BASE_URLS[protocol]
     # Save the data to a temporary directory

--- a/tests/integration/hourly_emissions_epacems_test.py
+++ b/tests/integration/hourly_emissions_epacems_test.py
@@ -24,7 +24,7 @@ TEST_FILTERS = year_state_filter(years=TEST_YEARS, states=TEST_STATES)
 
 logger = logging.getLogger(__name__)
 
-os.environ["PUDL_INTAKE_PATH"] = BASE_URLS["gs"]
+os.environ["PUDL_INTAKE_PATH"] = BASE_URLS["s3"]
 
 InternetProtocol = Literal["gs", "https", "s3"]
 


### PR DESCRIPTION
We got hit with some big egress fees for the `gs://intake.catalyst.coop` bucket in the last two days. We are pretty sure this is  because the CI runs the integration tests 8 times for each push to a PR. 0.12 $/GB * 8 runs * 4 downloads of the epacems data * 5 GB (size of EPA cems data) = ~$20 per push!! That's no good. 

This PR skips the GCS tests until we figure out how to download partitions of the data using intake. We didn't disable the s3 tests because AWS covers the egress fees and we'd still like to test our catalogs! We need to figure out how to pull partitions so our CI isn't downloading **160 GB** of CEMS data every time there is a push. 

I'm still not sure why we weren’t hit with big egress fees earlier in the catalog development.