### PR TITLE
Add WIF to tox-pytest, and also pass the right google creds

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -19,8 +19,8 @@ jobs:
         name: "Authenticate to Google Cloud"
         uses: "google-github-actions/auth@v1"
         with:
-          credentials_json: "${{ secrets.GOOGLE_CREDENTIALS }}"
-          export_environment_variables: true
+          workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"
+          service_account: "tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
 
       - name: Set up conda environment for testing
         uses: conda-incubator/setup-miniconda@v2.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -11,10 +11,13 @@ allowlist_externals =
 envdir = {toxinidir}/.env_tox
 passenv =
     CI
+    CLOUDSDK_*
     CONDA_PREFIX
     GITHUB_*
+    GOOGLE_*
+    GCLOUD_*
+    GCP_*
     HOME
-    GOOGLE_APPLICATION_CREDENTIALS
 
 covargs = --cov={envsitepackagesdir}/pudl_catalog --cov-append --cov-report=xml
 covreport = coverage report --sort=cover


### PR DESCRIPTION
Just trying to get rid of `credentials_json` everywhere.